### PR TITLE
[CAS-11554] Tries to solve issue with deadlocks when using MySQL as Queue driver

### DIFF
--- a/DbalConsumerHelperTrait.php
+++ b/DbalConsumerHelperTrait.php
@@ -137,17 +137,13 @@ trait DbalConsumerHelperTrait
         $attempts = 5;
 
         for ($attempt = 0; $attempt < $attempts; ++$attempt) {
-            $this->getConnection()->beginTransaction();
 
             try {
                 $delete->execute();
-
-                $this->getConnection()->commit();
                 break;
             } catch (\Throwable $e) {
-                $this->getConnection()->rollBack();
                 // maybe next time we'll get more luck
-                usleep(10000); // 10ms to increase the odds
+                usleep($attempt * 10000); // 150ms total (10ms+20ms+...) to increase the odds
                 continue;
             }
         }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-<h2 align="center">Supporting Enqueue</h2>
+## Intro-introduction
+This is a CastorEDC fork addressing deadlock issues with DBAL MySQL driver.
+
+For details check DbalConsumerHelperTrait.php.
+
+## Supporting Enqueue
 
 Enqueue is an MIT-licensed open source project with its ongoing development made possible entirely by the support of community and our customers. If you'd like to join them, please consider:
 


### PR DESCRIPTION
**NOTE:** This one is forked properly from php-enqueue/dbal and not from enqueue-dev.

Root of the issue is described [here](https://ph4r05.deadcode.me/blog/2017/12/23/laravel-queues-optimization.html).

This is a temporary solution that tries to solve deadlocks problem by retrying job delete few times. 

I tried reproducing deadlock issue under heavy machine load (and light load as well, 3 exact same workers running and 1500 jobs to be processed, but wasn't able to.

Then I tried running same exact setup with modified delete jobs code - no visible difference, so at least nothing's broke.

Next step would be to update EDC in this forked package.